### PR TITLE
PHP 8.1 | gensalt_blowfish(): prevent deprecation notice

### DIFF
--- a/PasswordHash.php
+++ b/PasswordHash.php
@@ -156,7 +156,7 @@ class PasswordHash {
 		$itoa64 = './ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
 		$output = '$2a$';
-		$output .= chr(ord('0') + $this->iteration_count_log2 / 10);
+		$output .= chr((int)(ord('0') + $this->iteration_count_log2 / 10));
 		$output .= chr(ord('0') + $this->iteration_count_log2 % 10);
 		$output .= '$';
 


### PR DESCRIPTION
The PHP `chr()` function expects an integer as the input parameter, but the output of `ord('0') + $this->iteration_count_log2 / 10` might be a floating point number.

While PHP type juggles between floats and integers, the number will likely loose precision when going from float to integer.

As of PHP 8.1, these type of "implicit float to int" conversions will throw a deprecation notice when precision is lost.

As this loss of precision is not an issue for this code, this small change make the type juggling explicit instead of implicit, which gets rid of the deprecation notice.

Ref:
* https://www.php.net/manual/en/function.chr.php
* https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.implicit-float-conversion