### PR TITLE
CI: add automated test runs via GH Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+
+    continue-on-error: ${{ matrix.php == '8.3' }}
+
+    name: "Test: PHP ${{ matrix.php }}"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
+          coverage: none
+
+      - name: Run tests
+        run: php ./test.php

--- a/test.php
+++ b/test.php
@@ -64,9 +64,12 @@ $check = $t_hasher->CheckPassword($wrong, $hash);
 if (!$check) $ok++;
 print "Check wrong: '" . $check . "' (should be '0' or '')\n";
 
-if ($ok === 6)
+if ($ok === 6) {
 	print "All tests have PASSED\n";
-else
+	exit(0);
+} else {
 	print "Some tests have FAILED\n";
+	exit(1);
+}
 
 ?>


### PR DESCRIPTION
(As discussed in #2)

This adds a workflow to automatically run the tests against PHP 5.3 - 8.3 on all pushes and pull requests to this repo.

Notes:
* The test run against PHP 8.3 is allowed to fail (for now) as PHP 8.3 is not stable yet.
* As the `setup-php` action runner does [not support PHP 5.0, 5.1 and 5.2](https://github.com/shivammathur/setup-php/#tada-php-support), the tests are not run against those PHP versions.

The commit includes a small change to the `test.php` script to send an exit code depending on whether the test run succeeded or failed. This is necessary to allow GH Actions to mark a build as failed.