### PR TITLE
GH Actions: various updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,15 +18,15 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
-    continue-on-error: ${{ matrix.php == '8.3' }}
+    continue-on-error: ${{ matrix.php == '8.4' }}
 
     name: "Test: PHP ${{ matrix.php }}"
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -43,15 +43,15 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
-    continue-on-error: ${{ matrix.php == '8.3' }}
+    continue-on-error: ${{ matrix.php == '8.4' }}
 
     name: "Unit Test: PHP ${{ matrix.php }}"
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -61,17 +61,17 @@ jobs:
           coverage: xdebug
 
       # Install dependencies and handle caching in one go.
-      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies - normal
-        if: ${{ matrix.php != '8.3' }}
-        uses: "ramsey/composer-install@v2"
+        if: ${{ matrix.php != '8.4' }}
+        uses: "ramsey/composer-install@v3"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Install Composer dependencies - ignore PHP restrictions
-        if: ${{ matrix.php == '8.3' }}
-        uses: "ramsey/composer-install@v2"
+        if: ${{ matrix.php == '8.4' }}
+        uses: "ramsey/composer-install@v3"
         with:
           composer-options: --ignore-platform-req=php+
           # Bust the cache at least once a month - output format: YYYY-MM.


### PR DESCRIPTION
1. Start running tests against PHP 8.4 (expected to be released end of November).
2. Update the `actions/checkout` action runner.
3. Update the `ramsey/composer-install` action runner.
4. Fix an outdated link.